### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ using Owin.WebSocket;
 
 public class MyWebSocket : WebSocketConnection
 {
-    public override Task OnMessageReceived(ArraySegment<byte> message, WebSocketMessageType type)
+    public override async Task OnMessageReceived(ArraySegment<byte> message, WebSocketMessageType type)
     {
        //Handle the message from the client
        
@@ -28,8 +28,8 @@ public class MyWebSocket : WebSocketConnection
     }
     
     //public override void OnOpen(){}
-    //public override void OnClose(WebSocketCloseStatus closeStatus, string closeDescription){}
-    //public override bool Authenticate(IOwinContext requestContext){return true;}
+    //public override void OnClose(WebSocketCloseStatus? closeStatus, string closeStatusDescription){}
+    //public override bool Authenticate(IOwinRequest request){return true;}
 }
 ```
 


### PR DESCRIPTION
Just updating the example, sorry if this is trivial.

#8 changed the return type, but without the async keyword there'd be an error