### PR TITLE
Project not compile if updating dependency CommonServiceLocator

### DIFF
--- a/src/Owin.WebSocket/Extensions/OwinExtension.cs
+++ b/src/Owin.WebSocket/Extensions/OwinExtension.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Owin.WebSocket.Extensions
 {

--- a/src/Owin.WebSocket/Owin.WebSocket.csproj
+++ b/src/Owin.WebSocket/Owin.WebSocket.csproj
@@ -38,13 +38,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommonServiceLocator, Version=2.0.5.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.2.0.5\lib\net45\CommonServiceLocator.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Owin.WebSocket/WebSocketConnectionMiddleware.cs
+++ b/src/Owin.WebSocket/WebSocketConnectionMiddleware.cs
@@ -2,7 +2,7 @@
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Owin;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using System;
 
 namespace Owin.WebSocket

--- a/src/Owin.WebSocket/packages.config
+++ b/src/Owin.WebSocket/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -41,6 +41,9 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommonServiceLocator, Version=2.0.5.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.2.0.5\lib\net45\CommonServiceLocator.dll</HintPath>
+    </Reference>
     <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -64,9 +67,6 @@
     <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/UnitTests/WebSocketTests.cs
+++ b/src/UnitTests/WebSocketTests.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 using Microsoft.Owin.Hosting;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Owin.WebSocket;
 using Owin.WebSocket.Extensions;

--- a/src/UnitTests/packages.config
+++ b/src/UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
+  <package id="CommonServiceLocator" version="2.0.5" targetFramework="net451" />
   <package id="FluentAssertions" version="4.2.1" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net451" />


### PR DESCRIPTION
Updated dependency has its namespace changed from Microsoft.Practices.ServiceLocation to CommonServiceLocator.
Ref:
https://github.com/unitycontainer/commonservicelocator/commit/908a30f0f4c036d1ded0c0967fa3a7ae823aa5ce
https://github.com/PrismLibrary/Prism/issues/1211